### PR TITLE
Typo in example script

### DIFF
--- a/docs/source/examples/instances_and_volumes.rst
+++ b/docs/source/examples/instances_and_volumes.rst
@@ -42,7 +42,7 @@ Instances and Volumes
                                                           ssh_key_ids=ssh_keys,
                                                           hostname='example',
                                                           description='example instance',
-                                                          os_volumes={
+                                                          os_volume={
                                                               "name": "OS volume",
                                                               "size": 95
                                                           })


### PR DESCRIPTION
There's a typo in the example for "Instances and Volumes" setting the os_volume parameters