### PR TITLE
image is missing in the instance json in state ordered

### DIFF
--- a/datacrunch/instances/instances.py
+++ b/datacrunch/instances/instances.py
@@ -349,7 +349,7 @@ class InstancesService:
         instance = Instance(
             id=instance_dict['id'],
             instance_type=instance_dict['instance_type'],
-            image=instance_dict['image'],
+            image=instance_dict['image'] if 'image' in instance_dict else None,
             price_per_hour=instance_dict['price_per_hour'] if 'price_per_hour' in instance_dict else None,
             location=instance_dict['location'],
             hostname=instance_dict['hostname'],


### PR DESCRIPTION
it seems that the field containing the image is no longer provided by the `GET/v1/instances/{instance_id}` endpoint if the instance is in state `ordered`

```
  File "/Users/frederikfix/src/konvenit/odin/providers/dc.py", line 175, in start
    instance = self._client.instances.create(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/frederikfix/.pyenv/versions/miceportal/lib/python3.12/site-packages/datacrunch/instances/instances.py", line 443, in create
    instance = self.get_by_id(id)
               ^^^^^^^^^^^^^^^^^^
  File "/Users/frederikfix/.pyenv/versions/miceportal/lib/python3.12/site-packages/datacrunch/instances/instances.py", line 352, in get_by_id
    image=instance_dict['image'],
          ~~~~~~~~~~~~~^^^^^^^^^
KeyError: 'image'
```

The json returned looks like this:
```
{'id': 'xxxx', 'ip': None, 'status': 'ordered', 'created_at': '2025-04-01T06:49:28.829Z', 'cpu': {'description': '4 CPU', 'number_of_cores': 4}, 'gpu': {'description': '', 'number_of_gpus': 0}, 'gpu_memory': {'description': '', 'size_in_gigabytes': 0}, 'memory': {'description': '16GB RAM', 'size_in_gigabytes': 16}, 'storage': {'description': 'dynamic'}, 'hostname': 'xxxx', 'description': 'DataCrunch Instance for frederik', 'location': 'FIN-01', 'price_per_hour': 0.0355, 'is_spot': False, 'instance_type': 'CPU.4V.16G', 'startup_script_id': 'xxx', 'ssh_key_ids': ['xxxx'], 'os_volume_id': None, 'jupyter_token': None, 'contract': 'PAY_AS_YOU_GO', 'pricing': 'DYNAMIC_PRICE'}
```