### PR TITLE
fix: removed print and minor changes

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -5,7 +5,7 @@ name: Upload Python Package
 
 on:
   release:
-    types: [published, created]
+    types: [published]
 
 jobs:
   deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Trigger publish package github action only when a released is published
+- Async inference example: longer `sleep()` duration when polling for inference status
+
+### Fixed
+
+- Removed a forgotten and redundant `print`
+
 ## [1.13.0] - 2025-05-21
 
 ### Changed

--- a/datacrunch/containers/containers.py
+++ b/datacrunch/containers/containers.py
@@ -921,7 +921,6 @@ class ContainersService:
             List[Secret]: List of all secrets.
         """
         response = self.client.get(SECRETS_ENDPOINT)
-        print(response.json())
         return [Secret.from_dict(secret) for secret in response.json()]
 
     def create_secret(self, name: str, value: str) -> None:

--- a/examples/containers/calling_the_endpoint_with_inference_key_async.py
+++ b/examples/containers/calling_the_endpoint_with_inference_key_async.py
@@ -30,7 +30,7 @@ async_inference_execution = inference_client.run(
 # Poll for status until completion
 while async_inference_execution.status() != AsyncStatus.Completed:
     print(async_inference_execution.status_json())
-    sleep(1)
+    sleep(5)
 
 # Print the response
 print(async_inference_execution.output())


### PR DESCRIPTION
### Changed

- Trigger publish package github action only when a released is published
- Async inference example: longer `sleep()` duration when polling for inference status

### Fixed

- Removed a forgotten and redundant `print`