### PR TITLE
Fix instances.create to send empty arrays instead of null for volume params

### DIFF
--- a/verda/instances/_instances.py
+++ b/verda/instances/_instances.py
@@ -171,8 +171,8 @@ class InstancesService:
             'description': description,
             'location_code': location,
             'os_volume': os_volume,
-            'volumes': volumes if volumes is not None else [],
-            'existing_volumes': existing_volumes if existing_volumes is not None else [],
+            'volumes': volumes or [],
+            'existing_volumes': existing_volumes or [],
             'is_spot': is_spot,
             'coupon': coupon,
         }


### PR DESCRIPTION
When volumes or existing_volumes parameters are None, send empty arrays [] to the REST API instead of null values. This ensures API compatibility and proper validation.

Fixes #56