### PR TITLE
fix: properly pass location_code

### DIFF
--- a/verda/instances/_instances.py
+++ b/verda/instances/_instances.py
@@ -256,5 +256,5 @@ class InstancesService:
             List of available instance types and their details.
         """
         is_spot = str(is_spot).lower() if is_spot is not None else None
-        query_params = {'isSpot': is_spot, 'locationCode': location_code}
+        query_params = {'isSpot': is_spot, 'location_code': location_code}
         return self._http_client.get('/instance-availability', params=query_params).json()


### PR DESCRIPTION
According to docs, it should be passed as `location_code` query param, not as `locationCode` https://api.datacrunch.io/v1/docs#tag/instance-availability/GET/v1/instance-availability