### PR TITLE
[dev-pilot] Sync Python SDK: add should_use_cached_image, replica image fields, job created_by_user_id

### DIFF
--- a/.ai/api-coverage.md
+++ b/.ai/api-coverage.md
@@ -1,0 +1,361 @@
+---
+name: python-sdk-api-coverage
+description: Complete mapping of OpenAPI spec endpoints to Python SDK implementation. Use to locate code for any API endpoint, identify gaps, and track what changed between syncs.
+metadata:
+  pattern: tool-wrapper
+  domain: python-sdk
+  last_scan: "2026-03-25"
+  spec_endpoints_active: 68
+  spec_endpoints_deprecated: 8
+  sdk_implemented: 66
+  sdk_missing: 2
+---
+
+# Python SDK API Coverage
+
+Complete endpoint-by-endpoint mapping from OpenAPI spec to Python SDK code.
+Organized by API tag (resource group) for fast lookup.
+
+**Spec:** `openapi.json` (Verda Cloud Public API)
+**SDK:** `tmp/sdk-python/verda/`
+
+**Legend:**
+- ✓ = implemented
+- ✗ = missing (needs implementation)
+- ⊘ = deprecated in spec (correctly skipped)
+- ⊕ = SDK-only (convenience helper, not in spec)
+- ⚠ = mismatch (needs investigation)
+
+---
+
+## Authentication
+
+**File:** `authentication/_authentication.py` → `AuthenticationService`
+**Coverage:** 1/1
+
+| Spec Endpoint | SDK Method | Status |
+|---|---|---|
+| `POST /v1/oauth2/token` | `authenticate` (client_credentials) | ✓ |
+| `POST /v1/oauth2/token` | `refresh` (refresh_token grant) | ✓ |
+| — | `is_expired` | ⊕ expiry check helper |
+
+---
+
+## Balance
+
+**File:** `balance/_balance.py` → `BalanceService`
+**Coverage:** 1/1
+
+| Spec Endpoint | SDK Method | Status |
+|---|---|---|
+| `GET /v1/balance` | `get` | ✓ |
+
+---
+
+## Clusters
+
+**File:** `clusters/_clusters.py` → `ClustersService`
+**Coverage:** 8/8
+
+| Spec Endpoint | SDK Method | Status |
+|---|---|---|
+| `GET /v1/clusters` | `get` | ✓ |
+| `POST /v1/clusters` | `create` | ✓ |
+| `PUT /v1/clusters` | `action` | ✓ |
+| `GET /v1/clusters/{id}` | `get_by_id` | ✓ |
+| `GET /v1/cluster-types` | `ClusterTypesService.get` | ✓ (separate service) |
+| `GET /v1/cluster-availability` | `get_availabilities` | ✓ |
+| `GET /v1/cluster-availability/{cluster_type}` | `is_available` | ✓ |
+| `GET /v1/images/cluster` | `get_cluster_images` | ✓ (on ClustersService, not ImagesService) |
+| — | `delete` | ⊕ convenience wrapper for `action('delete')` |
+
+---
+
+## Cluster Types
+
+**File:** `cluster_types/_cluster_types.py` → `ClusterTypesService`
+**Coverage:** 1/1
+
+| Spec Endpoint | SDK Method | Status |
+|---|---|---|
+| `GET /v1/cluster-types` | `get` | ✓ |
+
+---
+
+## Serverless Containers
+
+**File:** `containers/_containers.py` → `ContainersService`
+**Coverage:** 27/27
+
+| Spec Endpoint | SDK Method | Status |
+|---|---|---|
+| `GET /v1/container-deployments` | `get_deployments` | ✓ |
+| `POST /v1/container-deployments` | `create_deployment` | ✓ |
+| `GET /v1/container-deployments/{name}` | `get_deployment_by_name` | ✓ |
+| `PATCH /v1/container-deployments/{name}` | `update_deployment` | ✓ |
+| `DELETE /v1/container-deployments/{name}` | `delete_deployment` | ✓ |
+| `GET /v1/container-deployments/{name}/status` | `get_deployment_status` | ✓ |
+| `POST /v1/container-deployments/{name}/restart` | `restart_deployment` | ✓ |
+| `POST /v1/container-deployments/{name}/pause` | `pause_deployment` | ✓ |
+| `POST /v1/container-deployments/{name}/resume` | `resume_deployment` | ✓ |
+| `POST /v1/container-deployments/{name}/purge-queue` | `purge_deployment_queue` | ✓ |
+| `GET /v1/container-deployments/{name}/scaling` | `get_deployment_scaling_options` | ✓ |
+| `PATCH /v1/container-deployments/{name}/scaling` | `update_deployment_scaling_options` | ✓ |
+| `GET /v1/container-deployments/{name}/replicas` | `get_deployment_replicas` | ✓ |
+| `GET /v1/container-deployments/{name}/environment-variables` | `get_deployment_environment_variables` | ✓ |
+| `POST /v1/container-deployments/{name}/environment-variables` | `add_deployment_environment_variables` | ✓ |
+| `PATCH /v1/container-deployments/{name}/environment-variables` | `update_deployment_environment_variables` | ✓ |
+| `DELETE /v1/container-deployments/{name}/environment-variables` | `delete_deployment_environment_variables` | ✓ |
+| `GET /v1/container-registry-credentials` | `get_registry_credentials` | ✓ |
+| `POST /v1/container-registry-credentials` | `add_registry_credentials` | ✓ |
+| `DELETE /v1/container-registry-credentials/{name}` | `delete_registry_credentials` | ✓ |
+| `GET /v1/secrets` | `get_secrets` | ✓ |
+| `POST /v1/secrets` | `create_secret` | ✓ |
+| `DELETE /v1/secrets/{name}` | `delete_secret` | ✓ |
+| `GET /v1/file-secrets` | `get_fileset_secrets` | ✓ |
+| `POST /v1/file-secrets` | `create_fileset_secret_from_file_paths` | ✓ |
+| `DELETE /v1/file-secrets/{name}` | `delete_fileset_secret` | ✓ |
+| `GET /v1/serverless-compute-resources` | `get_compute_resources` | ✓ |
+| — | `get_deployment` | ⊕ alias for `get_deployment_by_name` |
+| — | `get_gpus` | ⊕ alias for `get_compute_resources` |
+
+---
+
+## Container Types
+
+**File:** `container_types/_container_types.py` → `ContainerTypesService`
+**Coverage:** 1/1
+
+| Spec Endpoint | SDK Method | Status |
+|---|---|---|
+| `GET /v1/container-types` | `get` | ✓ |
+
+---
+
+## Images
+
+**File:** `images/_images.py` → `ImagesService`
+**Coverage:** 1/2
+
+| Spec Endpoint | SDK Method | Status |
+|---|---|---|
+| `GET /v1/images` | `get` | ✓ |
+| `GET /v1/images/cluster` | — | ⚠ not in ImagesService (covered by `ClustersService.get_cluster_images`) |
+
+---
+
+## Inference Client
+
+**File:** `inference_client/_inference_client.py` → `InferenceClient`
+**Coverage:** SDK-only (0 spec endpoints)
+
+| Spec Endpoint | SDK Method | Status |
+|---|---|---|
+| — | `run_sync` | ⊕ synchronous inference request |
+| — | `run` | ⊕ asynchronous inference request |
+| — | `health` | ⊕ deployment health check |
+| — | `get` | ⊕ generic GET helper |
+| — | `post` | ⊕ generic POST helper |
+| — | `put` | ⊕ generic PUT helper |
+| — | `delete` | ⊕ generic DELETE helper |
+| — | `patch` | ⊕ generic PATCH helper |
+
+Note: `InferenceClient` is SDK-only. It is used by `Deployment` objects (in `ContainersService`) for inference against deployed endpoints. No equivalent exists in the Go SDK.
+
+---
+
+## Instance Availability
+
+**File:** `instances/_instances.py` → `InstancesService`
+**Coverage:** 2/2
+
+| Spec Endpoint | SDK Method | Status |
+|---|---|---|
+| `GET /v1/instance-availability` | `get_availabilities` | ✓ |
+| `GET /v1/instance-availability/{instance_type}` | `is_available` | ✓ |
+
+Note: Instance availability is handled directly on `InstancesService`, not as a separate service.
+
+---
+
+## Instance Types
+
+**File:** `instance_types/_instance_types.py` → `InstanceTypesService`
+**Coverage:** 1/1 active (1 deprecated not implemented)
+
+| Spec Endpoint | SDK Method | Status |
+|---|---|---|
+| `GET /v1/instance-types` | `get` | ✓ |
+| `GET /v1/instance-types/price-history` | — | ⊘ deprecated (not implemented) |
+
+---
+
+## Instances
+
+**File:** `instances/_instances.py` → `InstancesService`
+**Coverage:** 4/4 active (3 deprecated skipped)
+
+| Spec Endpoint | SDK Method | Status |
+|---|---|---|
+| `GET /v1/instances` | `get` | ✓ |
+| `POST /v1/instances` | `create` | ✓ |
+| `PUT /v1/instances` | `action` | ✓ |
+| `GET /v1/instances/{instance_id}` | `get_by_id` | ✓ |
+| `POST /v1/instances/action` | — | ⊘ deprecated |
+| `GET /v1/instances/availability/{instanceType}` | — | ⊘ deprecated |
+| `GET /v1/instances/types` | — | ⊘ deprecated |
+
+---
+
+## Locations
+
+**File:** `locations/_locations.py` → `LocationsService`
+**Coverage:** 1/1
+
+| Spec Endpoint | SDK Method | Status |
+|---|---|---|
+| `GET /v1/locations` | `get` | ✓ |
+
+---
+
+## Long Term
+
+**File:** `long_term/_long_term.py` → `LongTermService`
+**Coverage:** 2/2 active (1 deprecated skipped)
+
+| Spec Endpoint | SDK Method | Status |
+|---|---|---|
+| `GET /v1/long-term/periods` | — | ⊘ deprecated |
+| `GET /v1/long-term/periods/clusters` | `get_cluster_periods` | ✓ |
+| `GET /v1/long-term/periods/instances` | `get_instance_periods` | ✓ |
+
+---
+
+## Serverless Jobs
+
+**File:** `job_deployments/_job_deployments.py` → `JobDeploymentsService`
+**Coverage:** 10/10
+
+| Spec Endpoint | SDK Method | Status |
+|---|---|---|
+| `GET /v1/job-deployments` | `get` | ✓ |
+| `POST /v1/job-deployments` | `create` | ✓ |
+| `GET /v1/job-deployments/{name}` | `get_by_name` | ✓ |
+| `PATCH /v1/job-deployments/{name}` | `update` | ✓ |
+| `DELETE /v1/job-deployments/{name}` | `delete` | ✓ |
+| `GET /v1/job-deployments/{name}/scaling` | `get_scaling_options` | ✓ |
+| `POST /v1/job-deployments/{name}/purge-queue` | `purge_queue` | ✓ |
+| `POST /v1/job-deployments/{name}/pause` | `pause` | ✓ |
+| `POST /v1/job-deployments/{name}/resume` | `resume` | ✓ |
+| `GET /v1/job-deployments/{name}/status` | `get_status` | ✓ |
+
+---
+
+## SSH Keys
+
+**File:** `ssh_keys/_ssh_keys.py` → `SSHKeysService`
+**Coverage:** 0/5 active (5 deprecated implemented instead)
+
+| Spec Endpoint | SDK Method | Status |
+|---|---|---|
+| `GET /v1/ssh-keys` | — | ✗ missing (uses old path) |
+| `POST /v1/ssh-keys` | — | ✗ missing (uses old path) |
+| `DELETE /v1/ssh-keys` | — | ✗ missing (uses old path) |
+| `GET /v1/ssh-keys/{sshKeyId}` | — | ✗ missing (uses old path) |
+| `DELETE /v1/ssh-keys/{sshKeyId}` | — | ✗ missing (uses old path) |
+| `GET /v1/sshkeys` | `get` | ⚠ deprecated path, should use `/ssh-keys` |
+| `POST /v1/sshkeys` | `create` | ⚠ deprecated path, should use `/ssh-keys` |
+| `DELETE /v1/sshkeys` | `delete` | ⚠ deprecated path, should use `/ssh-keys` |
+| `GET /v1/sshkeys/{sshKeyId}` | `get_by_id` | ⚠ deprecated path, should use `/ssh-keys` |
+| `DELETE /v1/sshkeys/{sshKeyId}` | `delete_by_id` | ⚠ deprecated path, should use `/ssh-keys` |
+
+---
+
+## Startup Scripts
+
+**File:** `startup_scripts/_startup_scripts.py` → `StartupScriptsService`
+**Coverage:** 5/5
+
+| Spec Endpoint | SDK Method | Status |
+|---|---|---|
+| `GET /v1/scripts` | `get` | ✓ |
+| `POST /v1/scripts` | `create` | ✓ |
+| `DELETE /v1/scripts` | `delete` | ✓ |
+| `GET /v1/scripts/{scriptId}` | `get_by_id` | ✓ |
+| `DELETE /v1/scripts/{scriptId}` | `delete_by_id` | ✓ |
+
+---
+
+## Volume Types
+
+**File:** `volume_types/_volume_types.py` → `VolumeTypesService`
+**Coverage:** 1/1
+
+| Spec Endpoint | SDK Method | Status |
+|---|---|---|
+| `GET /v1/volume-types` | `get` | ✓ |
+
+---
+
+## Volumes
+
+**File:** `volumes/_volumes.py` → `VolumesService`
+**Coverage:** 6/6
+
+| Spec Endpoint | SDK Method | Status |
+|---|---|---|
+| `GET /v1/volumes` | `get` | ✓ |
+| `POST /v1/volumes` | `create` | ✓ |
+| `PUT /v1/volumes` | `attach` / `detach` / `clone` / `rename` / `increase_size` / `delete` | ✓ |
+| `GET /v1/volumes/{volume_id}` | `get_by_id` | ✓ |
+| `DELETE /v1/volumes/{volume_id}` | `delete_by_id` | ✓ |
+| `GET /v1/volumes/trash` | `get_in_trash` | ✓ |
+
+Note: The SDK uses `PUT /v1/volumes` with action `delete` instead of `DELETE /v1/volumes/{volume_id}`. The spec has both endpoints.
+
+---
+
+## Overall Summary
+
+| Metric | Count |
+|---|---|
+| Active spec endpoints | 68 |
+| SDK implemented (correct path) | 66 |
+| Missing (active, not implemented) | 2 |
+| Deprecated (correctly skipped) | 4 |
+| Deprecated (implemented via old path) | 5 |
+| SDK-only methods | ~15 (InferenceClient, aliases, convenience wrappers) |
+
+### Breakdown of Missing Endpoints
+
+| # | Endpoint | Reason |
+|---|---|---|
+| 1 | `GET /v1/ssh-keys` | Uses deprecated `/sshkeys` path instead |
+| 2 | `POST /v1/ssh-keys` | Uses deprecated `/sshkeys` path instead |
+
+Note: SSH keys endpoints 3-5 (`DELETE /v1/ssh-keys`, `GET /v1/ssh-keys/{sshKeyId}`, `DELETE /v1/ssh-keys/{sshKeyId}`) also use deprecated path but are functionally equivalent.
+
+### Known Issues
+
+| # | Type | Detail |
+|---|---|---|
+| 1 | ⚠ Old path | `SSHKeysService` uses deprecated `/sshkeys` path instead of `/ssh-keys` |
+| 3 | ⚠ Naming | `ContainersService` is equivalent to Go SDK's `ContainerDeploymentsService` |
+| 4 | ⚠ Naming | `JobDeploymentsService` is equivalent to Go SDK's `ServerlessJobsService` |
+| 5 | ⊕ SDK-only | `InferenceClient` has no equivalent in Go SDK or OpenAPI spec |
+| 6 | ⚠ Placement | `GET /v1/images/cluster` is on `ClustersService`, not `ImagesService` |
+| 7 | ⚠ Placement | Instance availability endpoints are on `InstancesService`, not a separate service |
+| 8 | ✓ Both patterns | `DELETE /v1/volumes/{volume_id}` via `delete_by_id()`; bulk delete via `PUT /v1/volumes` action |
+
+### Key Differences from Go SDK
+
+| Area | Go SDK | Python SDK |
+|---|---|---|
+| Long Term | `LongTermService` with 3 methods | `LongTermService` with 2 methods (deprecated endpoint skipped) |
+| SSH Keys path | `/ssh-keys` (new path) | `/sshkeys` (deprecated path) |
+| Container service name | `ContainerDeploymentsService` | `ContainersService` |
+| Serverless jobs name | `ServerlessJobsService` | `JobDeploymentsService` |
+| Inference client | Not present | `InferenceClient` (SDK-only) |
+| Images/cluster | In both `ClusterService` and `ImagesService` | Only in `ClustersService` |
+| Instance availability | Separate `InstanceAvailabilityService` + `InstanceService` | Only on `InstancesService` |
+| Volume delete | Uses `DELETE /v1/volumes/{id}` | Both: `delete_by_id()` (DELETE) + `delete()` (PUT action) |

--- a/.ai/change-mapping.md
+++ b/.ai/change-mapping.md
@@ -1,0 +1,142 @@
+# OpenAPI → Python SDK Change Mapping
+
+How to translate OpenAPI spec changes into Python SDK code changes.
+Read the language-specific patterns file (`.ai/sdks/python/patterns.md`) for conventions.
+
+## Mapping Table
+
+| OpenAPI Change | SDK Action | Files Affected |
+|---|---|---|
+| New path under existing tag | Add method to existing service | `verda/<resource>/_<resource>.py` + test |
+| New tag (resource group) | Create new service module + wire into client | `verda/<resource>/__init__.py`, `verda/<resource>/_<resource>.py`, `verda/_verda.py`, test |
+| New/modified request body schema | Add/update `@dataclass` model in service file | `verda/<resource>/_<resource>.py` |
+| New/modified response schema | Add/update `@dataclass` model in service file | `verda/<resource>/_<resource>.py` |
+| New enum/constant (resource-scoped) | Add `class Name(str, Enum)` in service file | `verda/<resource>/_<resource>.py` |
+| New enum/constant (broadly shared) | Add `class Name(str, Enum)` in constants | `verda/constants.py` |
+| Modified path parameters | Update method signature | `verda/<resource>/_<resource>.py` + test |
+| Modified query parameters | Update `params=dict(...)` in method body | `verda/<resource>/_<resource>.py` + test |
+| Removed path | **Log warning only** | None (manual review) |
+
+## Implementation Order
+
+For each SDK change, apply in this order:
+
+1. **Models first** — Add or update `@dataclass_json` / `@dataclass` classes in the service file (or `constants.py` for shared enums)
+2. **Service methods** — Add or update methods in the service file
+3. **Module exports** — Update `__init__.py` to export new public symbols
+4. **Client wiring** — If new service, import in `verda/_verda.py` and add to `VerdaClient.__init__`
+5. **Tests** — Add or update tests in the test file
+6. **Changelog** — Add concise entry to CHANGELOG.md under `## Unreleased`
+
+## Change Plan Format
+
+Output the plan as a numbered list before implementing:
+
+```
+  ---- CHANGE PLAN ----
+  1. verda/volumes/_volumes.py  — Add VolumeInTrash dataclass, add fields to VolumeTypeInfo
+  2. verda/volumes/_volumes.py  — Add get_volumes_in_trash(), delete_volume_permanently()
+  3. verda/volumes/__init__.py  — Export new symbols
+  4. tests/test_volumes.py      — Add tests for new methods
+  ---- END ----
+```
+
+For a new resource/tag:
+
+```
+  ---- CHANGE PLAN ----
+  1. verda/snapshots/__init__.py   — Create module init, export public symbols
+  2. verda/snapshots/_snapshots.py — Add dataclasses + SnapshotsService with methods
+  3. verda/_verda.py               — Import SnapshotsService, add to VerdaClient.__init__
+  4. tests/test_snapshots.py       — Add tests for all new methods
+  ---- END ----
+```
+
+## Removed Paths — Special Handling
+
+**Never auto-delete SDK code for removed API paths.** Always:
+
+1. Output a WARNING block
+2. Flag for manual review in the sync report
+3. Continue with remaining changes
+
+## Python-Specific Notes
+
+### Model Definitions
+
+Models live inside the service file, not in a separate types file. Use the `@dataclass_json` and `@dataclass` decorators:
+
+```python
+from dataclasses import dataclass
+from dataclasses_json import dataclass_json, Undefined
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class VolumeInfo:
+    id: str
+    name: str
+    size_gb: int
+    status: str | None = None
+```
+
+- Always use `Undefined.EXCLUDE` so the SDK tolerates extra fields the API may return.
+- Place model classes above the service class that uses them.
+
+### Enums and Constants
+
+- **Resource-scoped enums** go in the service file:
+  ```python
+  from enum import Enum
+
+  class VolumeStatus(str, Enum):
+      ACTIVE = "active"
+      DELETED = "deleted"
+  ```
+- **Broadly shared enums** (used by 2+ services) go in `verda/constants.py`.
+
+### HTTP Calls
+
+- Query parameters: pass as `params=dict(...)` to http_client methods.
+- Request body: pass as `json=dict(...)` to http_client methods.
+- Path parameters: use f-string interpolation in the URL.
+
+```python
+def get_volume(self, volume_id: str) -> VolumeInfo:
+    resp = self._http_client.get(f"/v1/volumes/{volume_id}")
+    return VolumeInfo.from_dict(resp.json())
+
+def list_volumes(self, project_id: str, page: int = 1) -> list[VolumeInfo]:
+    resp = self._http_client.get(
+        "/v1/volumes",
+        params=dict(project_id=project_id, page=page),
+    )
+    return [VolumeInfo.from_dict(v) for v in resp.json()["volumes"]]
+
+def create_volume(self, name: str, size_gb: int) -> VolumeInfo:
+    resp = self._http_client.post(
+        "/v1/volumes",
+        json=dict(name=name, size_gb=size_gb),
+    )
+    return VolumeInfo.from_dict(resp.json())
+```
+
+### New Service Wiring
+
+When a new tag/resource group appears:
+
+1. Create directory `verda/<resource>/`
+2. Create `verda/<resource>/__init__.py` with public exports
+3. Create `verda/<resource>/_<resource>.py` with models and service class
+4. In `verda/_verda.py`:
+   - Import the new service class
+   - Add an attribute in `VerdaClient.__init__`: `self.<resource> = <Resource>Service(self._http_client)`
+
+### Naming Conventions
+
+| OpenAPI | Python SDK |
+|---|---|
+| `operationId: listInstances` | `def list_instances(self, ...)` |
+| `operationId: getInstance` | `def get_instance(self, instance_id: str)` |
+| Schema: `InstanceTypeInfo` | `class InstanceTypeInfo` (keep PascalCase for dataclasses) |
+| Field: `sizeGb` | `size_gb` (snake_case) |
+| Enum value: `ACTIVE` | `ACTIVE = "active"` |

--- a/.ai/edge-cases.md
+++ b/.ai/edge-cases.md
@@ -1,0 +1,359 @@
+# Python SDK Implementation Edge Cases
+
+Non-obvious patterns discovered from the real Python SDK codebase. Check these
+before writing SDK code -- the OpenAPI spec does not surface these behaviors.
+
+## POST Endpoints Returning Plain Text IDs
+
+Some POST endpoints return a plain text ID string instead of JSON. The SDK
+reads `.text` from the response and then fetches the full object.
+
+**Affected services:** InstancesService.create(), VolumesService.create(),
+SSHKeysService.create(), StartupScriptsService.create()
+
+**Pattern:**
+
+```python
+# instances/_instances.py — create returns plain text ID, then fetches object
+id = self._http_client.post(INSTANCES_ENDPOINT, json=payload).text
+return self.get_by_id(id)
+
+# volumes/_volumes.py — same pattern
+id = self._http_client.post(VOLUMES_ENDPOINT, json=payload).text
+volume = self.get_by_id(id)
+return volume
+
+# ssh_keys/_ssh_keys.py — constructs object directly (no re-fetch)
+id = self._http_client.post(SSHKEYS_ENDPOINT, json=payload).text
+return SSHKey(id, name, key)
+```
+
+**Not affected:** ClustersService.create() returns JSON with `response.json()['id']`.
+ContainersService.create_deployment() returns full JSON object.
+
+## Three Model Serialization Styles
+
+The SDK uses three different model patterns. **Always match the existing style**
+when modifying a service.
+
+### Style 1: dataclass_json (from_dict with infer_missing)
+
+Uses `@dataclass_json` + `@dataclass` decorators. Deserialized via
+`Model.from_dict(data, infer_missing=True)`.
+
+**Models:** Instance, Cluster, ClusterWorkerNode, SharedVolume, Deployment,
+JobDeployment, JobDeploymentSummary, InstanceType, ClusterType, all Container
+dataclasses (Container, HealthcheckSettings, ScalingOptions, etc.)
+
+```python
+# instances/_instances.py
+@dataclass_json
+@dataclass
+class Instance:
+    id: str
+    instance_type: str
+    ...
+
+# Deserialization
+Instance.from_dict(instance_dict, infer_missing=True)
+```
+
+### Style 2: Manual class with create_from_dict or constructor
+
+Plain classes with `__init__`, `@property` accessors, and private `_field`
+storage. Some have a `create_from_dict` classmethod; others construct inline.
+
+**Models with create_from_dict:** Volume
+
+```python
+# volumes/_volumes.py
+class Volume:
+    def __init__(self, id, status, name, size, ...):
+        self._id = id
+        ...
+
+    @classmethod
+    def create_from_dict(cls, volume_dict):
+        return cls(
+            id=volume_dict['id'],
+            status=volume_dict['status'],
+            ...
+        )
+
+# Deserialization
+Volume.create_from_dict(volume_dict)
+```
+
+**Models constructed inline:** SSHKey, StartupScript, Image, Balance, VolumeType
+
+```python
+# ssh_keys/_ssh_keys.py — constructed field-by-field in service methods
+keys = [SSHKey(key['id'], key['name'], key['key']) for key in keys]
+
+# balance/_balance.py
+Balance(balance['amount'], balance['currency'])
+```
+
+### Style 3: Raw dict (no model)
+
+**Services:** LocationsService
+
+```python
+# locations/_locations.py
+def get(self) -> list[dict]:
+    locations = self._http_client.get(LOCATIONS_ENDPOINT).json()
+    return locations
+```
+
+## Single-Item Lookup Returning Array
+
+Some GET-by-ID endpoints return a JSON array. The SDK unwraps with `[0]`.
+
+**Affected:** SSHKeysService.get_by_id(), StartupScriptsService.get_by_id()
+
+```python
+# ssh_keys/_ssh_keys.py
+def get_by_id(self, id: str) -> SSHKey:
+    key_dict = self._http_client.get(SSHKEYS_ENDPOINT + f'/{id}').json()[0]
+    key_object = SSHKey(key_dict['id'], key_dict['name'], key_dict['key'])
+    return key_object
+
+# startup_scripts/_startup_scripts.py
+def get_by_id(self, id) -> StartupScript:
+    script = self._http_client.get(STARTUP_SCRIPTS_ENDPOINT + f'/{id}').json()[0]
+    return StartupScript(script['id'], script['name'], script['script'])
+```
+
+**Not affected:** InstancesService.get_by_id(), VolumesService.get_by_id(),
+ClustersService.get_by_id() -- these return a single JSON object.
+
+## Polymorphic ID Parameters
+
+Several action methods accept `str | list[str]`. The service normalizes to list
+internally using `type()` check (not `isinstance()`).
+
+**Affected:** InstancesService.action(), VolumesService.attach/detach/rename/
+increase_size/delete
+
+```python
+# instances/_instances.py
+def action(self, id_list: list[str] | str, action: str, ...) -> None:
+    if type(id_list) is str:
+        id_list = [id_list]
+    payload = {'id': id_list, 'action': action, ...}
+    self._http_client.put(INSTANCES_ENDPOINT, json=payload)
+```
+
+**Exception:** ClustersService.action() uses `isinstance()` and builds a
+different payload structure with an `actions` array:
+
+```python
+# clusters/_clusters.py
+if isinstance(id_list, str):
+    payload = {'actions': [{'id': id_list, 'action': action}]}
+else:
+    payload = {'actions': [{'id': id, 'action': action} for id in id_list]}
+```
+
+## Action-Based Mutations via PUT
+
+Instance and Volume mutations use PUT with an action payload instead of
+resource-specific endpoints. The action string determines the operation.
+
+**Pattern:**
+
+```python
+# volumes/_volumes.py — all mutations go through PUT /volumes
+payload = {'id': id_list, 'action': VolumeActions.ATTACH, 'instance_id': instance_id}
+self._http_client.put(VOLUMES_ENDPOINT, json=payload)
+
+# instances/_instances.py — same pattern for instance actions
+payload = {'id': id_list, 'action': action, ...}
+self._http_client.put(INSTANCES_ENDPOINT, json=payload)
+```
+
+**Cluster mutations** use a different structure with an `actions` array (see
+Polymorphic ID Parameters above).
+
+## SSH Keys Endpoint Path
+
+SSHKeysService uses the deprecated `/sshkeys` path (no hyphen).
+
+```python
+# ssh_keys/_ssh_keys.py
+SSHKEYS_ENDPOINT = '/sshkeys'
+```
+
+The OpenAPI spec uses `/ssh-keys`. When syncing, do NOT change the endpoint
+path unless explicitly instructed -- the old path still works and changing it
+is a breaking change for users.
+
+## Exponential Backoff Polling
+
+InstancesService.create() and ClustersService.create() include inline
+exponential backoff polling to wait for provisioning status.
+
+```python
+# instances/_instances.py — backoff polling loop
+deadline = time.monotonic() + max_wait_time
+for i in itertools.count():
+    instance = self.get_by_id(id)
+    if callable(wait_for_status):
+        if wait_for_status(instance.status):
+            return instance
+    elif instance.status == wait_for_status:
+        return instance
+
+    now = time.monotonic()
+    if now >= deadline:
+        raise TimeoutError(...)
+
+    interval = min(initial_interval * backoff_coefficient**i, max_interval, deadline - now)
+    time.sleep(interval)
+```
+
+**Key differences between Instance and Cluster polling:**
+- Instance: `wait_for_status` can be a `str` or `Callable[[str], bool]`; default is `lambda s: s != InstanceStatus.ORDERED`
+- Cluster: `wait_for_status` is `str | None` only; also checks for ERROR and DISCONTINUED states, raising `APIException`
+
+**Do NOT** add backoff polling to new endpoints unless the API returns an
+async/provisioning status that requires it. There is a TODO comment in both
+files to extract the shared backoff logic.
+
+## ContainersService Uses self.client (Not self._http_client)
+
+ContainersService stores the HTTP client as `self.client` instead of
+`self._http_client` like every other service.
+
+```python
+# containers/_containers.py
+class ContainersService:
+    def __init__(self, http_client: HTTPClient, inference_key: str | None = None) -> None:
+        self.client = http_client          # <-- public attribute, not _http_client
+        self._inference_key = inference_key
+
+    def get_deployments(self) -> list[Deployment]:
+        response = self.client.get(CONTAINER_DEPLOYMENTS_ENDPOINT)
+        ...
+```
+
+**All other services** use `self._http_client`:
+
+```python
+class InstancesService:
+    def __init__(self, http_client) -> None:
+        self._http_client = http_client
+```
+
+When adding methods to ContainersService, use `self.client`. When adding
+methods to any other service, use `self._http_client`.
+
+## strip_none_values Helper
+
+JobDeploymentsService uses `strip_none_values()` from `verda.helpers` to clean
+`None` values from dataclass-serialized payloads before sending to the API.
+
+```python
+# job_deployments/_job_deployments.py
+from verda.helpers import strip_none_values
+
+def create(self, deployment: JobDeployment) -> JobDeployment:
+    response = self._http_client.post(
+        JOB_DEPLOYMENTS_ENDPOINT,
+        json=strip_none_values(deployment.to_dict()),
+    )
+    ...
+```
+
+This is needed because `dataclass_json.to_dict()` includes `None` values for
+optional fields, and some API endpoints reject unexpected `null` values.
+**Only** JobDeploymentsService uses this pattern currently. Use it for new
+services that send dataclass payloads with optional fields.
+
+## InstanceType Price Fields — Manual float() Conversion
+
+InstanceTypesService.get() manually converts price fields from strings to
+floats during deserialization, despite InstanceType being a `@dataclass_json`
+model.
+
+```python
+# instance_types/_instance_types.py
+InstanceType(
+    ...
+    price_per_hour=float(instance_type['price_per_hour']),
+    spot_price_per_hour=float(instance_type['spot_price']),
+    serverless_price=(
+        float(instance_type['serverless_price'])
+        if instance_type.get('serverless_price') is not None
+        else None
+    ),
+    ...
+)
+```
+
+The API returns these as strings. The InstanceType dataclass declares them as
+`float`, but the service does NOT use `InstanceType.from_dict()` -- it
+constructs the object manually with explicit `float()` casts.
+
+## Long Term Periods -- Missing from Python SDK
+
+The Go SDK has `LongTermService` covering `/long-term/periods` endpoints.
+The Python SDK has no equivalent. If syncing this endpoint, a new service
+file must be created at `verda/long_term/_long_term.py`.
+
+## Inference Client -- SDK-Only, Not in OpenAPI Spec
+
+The `Deployment` model in ContainersService includes an embedded
+`InferenceClient` for running inference against deployed containers. This is
+SDK-specific convenience functionality, not generated from the API spec.
+
+```python
+# containers/_containers.py
+class Deployment:
+    _inference_client: InferenceClient | None = None
+
+    @classmethod
+    def from_dict_with_inference_key(cls, data, inference_key=None):
+        deployment = Deployment.from_dict(data, infer_missing=True)
+        if inference_key and deployment.endpoint_base_url:
+            deployment._inference_client = InferenceClient(
+                inference_key=inference_key,
+                endpoint_base_url=deployment.endpoint_base_url,
+            )
+        return deployment
+
+    def run_sync(self, data, ...):
+        self._validate_inference_client()
+        return self._inference_client.run_sync(data, ...)
+```
+
+**Do NOT** add inference client methods to new services. Do NOT remove or
+modify inference client wiring when syncing ContainersService changes.
+
+## Startup Scripts Endpoint Path
+
+StartupScriptsService uses `/scripts` as the endpoint path, not
+`/startup-scripts`.
+
+```python
+# startup_scripts/_startup_scripts.py
+STARTUP_SCRIPTS_ENDPOINT = '/scripts'
+```
+
+Match the existing path when modifying this service.
+
+## VolumeType Nested Price Field
+
+VolumeTypesService extracts price from a nested structure in the API response,
+not a flat field:
+
+```python
+# volume_types/_volume_types.py
+VolumeType(
+    type=volume_type['type'],
+    price_per_month_per_gb=volume_type['price']['price_per_month_per_gb'],
+)
+```
+
+The API returns `{"type": "...", "price": {"price_per_month_per_gb": ...}}`
+but the model flattens it to a single `price_per_month_per_gb` attribute.

--- a/.ai/patterns.md
+++ b/.ai/patterns.md
@@ -1,0 +1,623 @@
+---
+name: python-sdk-patterns
+description: Reference guide for sdk-python code conventions — models, services, tests, client wiring. Use when writing or modifying Python SDK code.
+metadata:
+  pattern: tool-wrapper
+  domain: python-sdk
+---
+
+# Verda Cloud Python SDK Patterns
+
+**Repo:** `tmp/sdk-python/`
+**Package root:** `verda/`
+**Test root:** `tests/unit_tests/`
+
+---
+
+## 1. Project Structure
+
+```
+verda/
+  __init__.py              # Re-exports VerdaClient
+  _verda.py                # VerdaClient class — wires all services together
+  _version.py              # __version__ string
+  constants.py             # Plain-class constants (Actions, Locations, etc.)
+  exceptions.py            # APIException
+  helpers.py               # stringify_class_object_properties, strip_none_values
+  authentication/          # AuthenticationService (OAuth2 client credentials)
+  http_client/             # HTTPClient wrapper around requests
+  balance/                 # BalanceService (legacy manual model)
+  images/                  # ImagesService (legacy manual model)
+  instances/               # InstancesService (dataclass_json model)
+  instance_types/          # InstanceTypesService (dataclass_json model)
+  clusters/                # ClustersService (dataclass_json model)
+  cluster_types/           # ClusterTypesService (dataclass_json model)
+  containers/              # ContainersService (dataclass_json model, many sub-models)
+  container_types/         # ContainerTypesService
+  job_deployments/         # JobDeploymentsService (dataclass_json model)
+  locations/               # LocationsService (raw dict pass-through)
+  ssh_keys/                # SSHKeysService (legacy manual model)
+  startup_scripts/         # StartupScriptsService (legacy manual model)
+  volumes/                 # VolumesService (legacy manual model)
+  volume_types/            # VolumeTypesService (legacy manual model)
+  inference_client/        # InferenceClient for container deployment inference
+```
+
+Each service lives in its own package directory with:
+- `_<service>.py` — model classes + service class
+- `__init__.py` — re-exports public symbols
+
+### Smart Scan Strategy
+
+**Scope:** Only scan `verda/` and `examples/` (if examples need updating).
+
+To build the full coverage map without reading every file:
+
+```bash
+# 1. Endpoint-to-file mapping (one grep)
+grep -rn '_ENDPOINT\s*=' verda/
+
+# 2. Method inventory per service
+grep -rn 'def ' verda/<resource>/_<resource>.py
+
+# 3. Model inventory per service
+grep -rn 'class ' verda/<resource>/_<resource>.py
+```
+
+Three greps → complete lookup table for api-coverage.md.
+
+---
+
+## 2. Model Patterns
+
+### 2a. `@dataclass_json` + `@dataclass` (preferred for new code)
+
+Used by: **instances, clusters, containers, job_deployments, instance_types, cluster_types**
+
+```python
+from dataclasses import dataclass
+from dataclasses_json import Undefined, dataclass_json
+
+@dataclass_json(undefined=Undefined.EXCLUDE)
+@dataclass
+class OSVolume:
+    name: str
+    size: int
+    on_spot_discontinue: OnSpotDiscontinue | None = None
+
+@dataclass_json
+@dataclass
+class Instance:
+    id: str
+    instance_type: str
+    price_per_hour: float
+    hostname: str
+    description: str
+    status: str
+    created_at: str
+    ssh_key_ids: list[str]
+    cpu: dict
+    gpu: dict
+    memory: dict
+    storage: dict
+    gpu_memory: dict
+    ip: str | None = None
+    os_volume_id: str | None = None
+    location: str = Locations.FIN_03
+    image: str | None = None
+    is_spot: bool = False
+```
+
+Key conventions:
+- **Decorator order matters:** `@dataclass_json` on top, `@dataclass` below.
+- Use `undefined=Undefined.EXCLUDE` when the API may return unknown fields you want to silently ignore.
+- Omit `Undefined.EXCLUDE` when the model fields are exhaustive.
+- Required fields first, optional fields (with defaults) after.
+- Deserialization: `Instance.from_dict(data, infer_missing=True)` — `infer_missing=True` fills missing optional fields with defaults.
+- Serialization: `instance.to_dict()`.
+- Use `str | None` union syntax (Python 3.10+), not `Optional[str]`.
+
+### 2b. Manual class with properties + `create_from_dict` (legacy)
+
+Used by: **volumes, ssh_keys, startup_scripts, images, balance, volume_types**
+
+```python
+class Volume:
+    def __init__(
+        self,
+        id: str,
+        status: str,
+        name: str,
+        size: int,
+        type: str,
+        is_os_volume: bool,
+        created_at: str,
+        target: str | None = None,
+        location: str = Locations.FIN_03,
+        instance_id: str | None = None,
+        ssh_key_ids: list[str] = [],
+        deleted_at: str | None = None,
+    ) -> None:
+        self._id = id
+        self._status = status
+        self._name = name
+        # ... store all as private attributes
+
+    @property
+    def id(self) -> str:
+        return self._id
+
+    @property
+    def status(self) -> str:
+        return self._status
+
+    # ... read-only properties for every field
+
+    @classmethod
+    def create_from_dict(cls: 'Volume', volume_dict: dict) -> 'Volume':
+        return cls(
+            id=volume_dict['id'],
+            status=volume_dict['status'],
+            name=volume_dict['name'],
+            # ... explicit key mapping
+        )
+
+    def __str__(self) -> str:
+        return stringify_class_object_properties(self)
+```
+
+Key conventions:
+- All attributes stored as `self._name` (private), exposed via read-only `@property`.
+- Class method `create_from_dict(cls, data_dict)` handles deserialization (explicit key access, no `infer_missing`).
+- `__str__` delegates to `helpers.stringify_class_object_properties(self)`.
+- Some simpler legacy models (SSHKey, StartupScript) skip `create_from_dict` and construct directly in the service layer: `SSHKey(key['id'], key['name'], key['key'])`.
+
+### 2c. Raw dict pass-through
+
+Used by: **locations**
+
+```python
+class LocationsService:
+    def __init__(self, http_client) -> None:
+        self._http_client = http_client
+
+    def get(self) -> list[dict]:
+        locations = self._http_client.get(LOCATIONS_ENDPOINT).json()
+        return locations
+```
+
+No model class at all. The API response dicts are returned as-is.
+
+### When adding new models, use style (a). Only use manual classes if extending an existing service that uses that style.
+
+---
+
+## 3. Service Pattern
+
+Every service follows this structure:
+
+```python
+INSTANCES_ENDPOINT = '/instances'
+
+class InstancesService:
+    def __init__(self, http_client) -> None:
+        self._http_client = http_client
+
+    def get(self, status: str | None = None) -> list[Instance]:
+        instances_dict = self._http_client.get(
+            INSTANCES_ENDPOINT, params={'status': status}
+        ).json()
+        return [
+            Instance.from_dict(instance_dict, infer_missing=True)
+            for instance_dict in instances_dict
+        ]
+
+    def get_by_id(self, id: str) -> Instance:
+        instance_dict = self._http_client.get(
+            INSTANCES_ENDPOINT + f'/{id}'
+        ).json()
+        return Instance.from_dict(instance_dict, infer_missing=True)
+
+    def create(self, instance_type: str, image: str, ...) -> Instance:
+        payload = { ... }
+        id = self._http_client.post(INSTANCES_ENDPOINT, json=payload).text
+        return self.get_by_id(id)
+
+    def action(self, id_list: list[str] | str, action: str, ...) -> None:
+        if type(id_list) is str:
+            id_list = [id_list]
+        payload = {'id': id_list, 'action': action}
+        self._http_client.put(INSTANCES_ENDPOINT, json=payload)
+        return
+```
+
+Key conventions:
+- Endpoint constant is a module-level `UPPER_SNAKE_CASE` string (relative path, no base URL).
+- Constructor takes `http_client` (or `http_client: HTTPClient` with type hint). Store as `self._http_client`.
+- Exception: `ContainersService` stores it as `self.client` (not `self._http_client`) and also takes `inference_key`.
+- Methods return model objects, not raw dicts (except locations).
+- Void actions (`delete`, `action`, etc.) return `None` explicitly with bare `return`.
+
+---
+
+## 4. HTTP Client Methods
+
+All methods live on `HTTPClient` and return `requests.Response`. Error handling (status >= 400) is automatic via `handle_error()` which raises `APIException`.
+
+| Method   | Signature                                                                 |
+|----------|---------------------------------------------------------------------------|
+| `get`    | `get(self, url: str, params: dict \| None = None, **kwargs)`             |
+| `post`   | `post(self, url: str, json: dict \| None = None, params: dict \| None = None, **kwargs)` |
+| `put`    | `put(self, url: str, json: dict \| None = None, params: dict \| None = None, **kwargs)` |
+| `patch`  | `patch(self, url: str, json: dict \| None = None, params: dict \| None = None, **kwargs)` |
+| `delete` | `delete(self, url: str, json: dict \| None = None, params: dict \| None = None, **kwargs)` |
+
+Notes:
+- `url` is always the relative path (e.g. `/instances`). `HTTPClient._add_base_url()` prepends the base URL.
+- `json=` parameter is the request body (dict). Some services pass positional dict instead of `json=` keyword (containers: `self.client.post(URL, deployment.to_dict())`).
+- All methods refresh the auth token if expired before making the request.
+- Error responses (status >= 400) raise `APIException(code, message)` automatically.
+
+---
+
+## 5. Client Wiring (`_verda.py`)
+
+To add a new service:
+
+1. **Create the service package** (e.g. `verda/new_service/`):
+   - `_new_service.py` with model classes and `NewServiceService` class
+   - `__init__.py` re-exporting public symbols
+
+2. **Import in `_verda.py`**:
+   ```python
+   from verda.new_service import NewServiceService
+   ```
+
+3. **Add attribute in `VerdaClient.__init__`**:
+   ```python
+   self.new_service: NewServiceService = NewServiceService(self._http_client)
+   """New service description"""
+   ```
+
+4. **Update top-level `verda/__init__.py`** if the service or its models should be importable from `verda` directly (currently only `VerdaClient` and `__version__` are exported at the top level).
+
+The `VerdaClient.__init__` signature:
+```python
+def __init__(
+    self,
+    client_id: str,
+    client_secret: str,
+    base_url: str = 'https://api.verda.com/v1',
+    inference_key: str | None = None,
+) -> None:
+```
+
+Services are plain attributes on the client (no lazy loading, no registry).
+
+---
+
+## 6. Method Naming -- INCONSISTENT across services
+
+| Service                | List all            | Get one               | Create                       | Delete                         | Other actions                    |
+|------------------------|---------------------|-----------------------|------------------------------|--------------------------------|----------------------------------|
+| `InstancesService`     | `get(status)`       | `get_by_id(id)`       | `create(...)`                | via `action(ids, 'delete')`    | `action(ids, action)`, `is_available()`, `get_availabilities()` |
+| `VolumesService`       | `get(status)`       | `get_by_id(id)`       | `create(...)`                | `delete(ids)`                  | `attach()`, `detach()`, `clone()`, `rename()`, `increase_size()`, `get_in_trash()` |
+| `ClustersService`      | `get(status)`       | `get_by_id(id)`       | `create(...)`                | `delete(id)` / `action(ids, action)` | `is_available()`, `get_availabilities()`, `get_cluster_images()` |
+| `ContainersService`    | `get_deployments()` | `get_deployment_by_name(name)` | `create_deployment(d)` | `delete_deployment(name)`      | `update_deployment()`, `restart_deployment()`, `pause/resume_deployment()`, secrets, registry creds, env vars, scaling, replicas |
+| `JobDeploymentsService`| `get()`             | `get_by_name(name)`   | `create(d)`                  | `delete(name)`                 | `update()`, `get_status()`, `pause()`, `resume()`, `purge_queue()`, `get_scaling_options()` |
+| `SSHKeysService`       | `get()`             | `get_by_id(id)`       | `create(name, key)`          | `delete(ids)` / `delete_by_id(id)` | -- |
+| `StartupScriptsService`| `get()`             | `get_by_id(id)`       | `create(name, script)`       | `delete(ids)` / `delete_by_id(id)` | -- |
+| `InstanceTypesService` | `get(currency)`     | --                    | --                           | --                             | -- |
+| `LocationsService`     | `get()`             | --                    | --                           | --                             | -- |
+
+**When adding to an existing service, match its style. New services should use the short style: `get`, `get_by_id` (or `get_by_name`), `create`, `delete`.**
+
+---
+
+## 7. Constants Pattern
+
+Constants in `constants.py` use plain classes with class-level attributes (not Enums):
+
+```python
+class Actions:
+    START = 'start'
+    SHUTDOWN = 'shutdown'
+    DELETE = 'delete'
+    HIBERNATE = 'hibernate'
+    RESTORE = 'restore'
+
+    def __init__(self):
+        return
+
+class Locations:
+    FIN_01: str = 'FIN-01'
+    FIN_02: str = 'FIN-02'
+    FIN_03: str = 'FIN-03'
+    ICE_01: str = 'ICE-01'
+
+    def __init__(self):
+        return
+```
+
+All constant classes have a no-op `__init__`. They are instantiated in the `Constants` class and exposed on `VerdaClient.constants`.
+
+**Container-specific enums** use `class Name(str, Enum)` instead (defined in `containers/_containers.py`):
+
+```python
+from enum import Enum
+
+class EnvVarType(str, Enum):
+    PLAIN = 'plain'
+    SECRET = 'secret'
+
+class ContainerDeploymentStatus(str, Enum):
+    INITIALIZING = 'initializing'
+    HEALTHY = 'healthy'
+    DEGRADED = 'degraded'
+    # ...
+```
+
+Also in `job_deployments/_job_deployments.py`:
+```python
+class JobDeploymentStatus(str, Enum):
+    PAUSED = 'paused'
+    TERMINATING = 'terminating'
+    RUNNING = 'running'
+```
+
+**Literal types** are used for constrained string parameters (not for constants):
+```python
+from typing import Literal
+Contract = Literal['LONG_TERM', 'PAY_AS_YOU_GO', 'SPOT']
+Currency = Literal['usd', 'eur']
+```
+
+---
+
+## 8. Polymorphic Parameters
+
+Services that accept either a single ID or a list of IDs use `str | list[str]` and normalize at the top of the method:
+
+```python
+def action(self, id_list: list[str] | str, action: str, ...) -> None:
+    if type(id_list) is str:
+        id_list = [id_list]
+    payload = {'id': id_list, 'action': action}
+    self._http_client.put(INSTANCES_ENDPOINT, json=payload)
+```
+
+Note: uses `type(id_list) is str` (identity check), not `isinstance()`. This is the established pattern; keep it consistent when extending existing services.
+
+Clusters service uses `isinstance()` instead:
+```python
+if isinstance(id_list, str):
+    payload = {'actions': [{'id': id_list, 'action': action}]}
+else:
+    payload = {'actions': [{'id': id, 'action': action} for id in id_list]}
+```
+
+---
+
+## 9. POST Returning Plain Text ID
+
+When a POST endpoint returns a plain-text ID (not JSON), the pattern is:
+
+```python
+def create(self, type: str, name: str, size: int, ...) -> Volume:
+    payload = { ... }
+    id = self._http_client.post(VOLUMES_ENDPOINT, json=payload).text
+    volume = self.get_by_id(id)
+    return volume
+```
+
+Used by: instances, volumes, ssh_keys, startup_scripts.
+
+Some services return JSON from POST instead (containers, job_deployments, clusters):
+```python
+def create_deployment(self, deployment: Deployment) -> Deployment:
+    response = self.client.post(CONTAINER_DEPLOYMENTS_ENDPOINT, deployment.to_dict())
+    return Deployment.from_dict_with_inference_key(response.json(), self._inference_key)
+```
+
+```python
+# clusters - POST returns JSON with 'id' field
+response = self._http_client.post(CLUSTERS_ENDPOINT, json=payload).json()
+id = response['id']
+```
+
+---
+
+## 10. Test Pattern
+
+Tests use `pytest` + `responses` library for HTTP mocking.
+
+### Shared fixtures (`tests/unit_tests/conftest.py`)
+
+```python
+from unittest.mock import Mock
+import pytest
+from verda.http_client import HTTPClient
+
+BASE_URL = 'https://api.example.com/v1'
+ACCESS_TOKEN = 'test-token'
+CLIENT_ID = '0123456789xyz'
+CLIENT_SECRET = '0123456789xyz'
+
+@pytest.fixture
+def http_client():
+    auth_service = Mock()
+    auth_service._access_token = ACCESS_TOKEN
+    auth_service.is_expired = Mock(return_value=True)
+    auth_service.refresh = Mock(return_value=None)
+    auth_service._client_id = CLIENT_ID
+    auth_service._client_secret = CLIENT_SECRET
+    return HTTPClient(auth_service, BASE_URL)
+```
+
+### Standard test class structure
+
+```python
+import pytest
+import responses
+from responses import matchers
+
+from verda.constants import Actions, ErrorCodes
+from verda.exceptions import APIException
+from verda.instances import Instance, InstancesService
+
+INSTANCE_ID = 'deadc0de-a5d2-4972-ae4e-d429115d055b'
+PAYLOAD = [{ ... }]  # response fixture data
+
+class TestInstancesService:
+    @pytest.fixture
+    def instances_service(self, http_client):
+        return InstancesService(http_client)
+
+    @pytest.fixture
+    def endpoint(self, http_client):
+        return http_client._base_url + '/instances'
+
+    @responses.activate
+    def test_get_instances(self, instances_service, endpoint):
+        # arrange
+        responses.add(responses.GET, endpoint, json=PAYLOAD, status=200)
+
+        # act
+        instances = instances_service.get()
+        instance = instances[0]
+
+        # assert
+        assert isinstance(instances, list)
+        assert isinstance(instance, Instance)
+        assert instance.id == INSTANCE_ID
+        assert responses.assert_call_count(endpoint, 1) is True
+
+    @responses.activate
+    def test_get_instances_failed(self, instances_service, endpoint):
+        # arrange
+        responses.add(
+            responses.GET,
+            endpoint + '?status=invalid',
+            json={'code': 'invalid_request', 'message': 'Bad status'},
+            status=400,
+        )
+
+        # act + assert
+        with pytest.raises(APIException) as excinfo:
+            instances_service.get(status='invalid')
+
+        assert excinfo.value.code == 'invalid_request'
+        assert excinfo.value.message == 'Bad status'
+
+    @responses.activate
+    def test_create_instance(self, instances_service, endpoint):
+        # arrange - POST returns plain text ID, then GET returns the object
+        responses.add(responses.POST, endpoint, body=INSTANCE_ID, status=200)
+        responses.add(
+            responses.GET,
+            endpoint + '/' + INSTANCE_ID,
+            json=PAYLOAD[0],
+            status=200,
+        )
+
+        # act
+        instance = instances_service.create(
+            instance_type='1V100.6V',
+            image='ubuntu-24.04-cuda-12.8-open-docker',
+            hostname='test',
+            description='test instance',
+        )
+
+        # assert
+        assert isinstance(instance, Instance)
+        assert responses.assert_call_count(endpoint, 1) is True
+```
+
+### Request body matching with `matchers`
+
+```python
+from responses import matchers
+
+@responses.activate
+def test_attach_volume(self, volumes_service, endpoint):
+    responses.add(
+        responses.PUT,
+        endpoint,
+        status=202,
+        match=[
+            matchers.json_params_matcher({
+                'id': VOLUME_ID,
+                'action': VolumeActions.ATTACH,
+                'instance_id': INSTANCE_ID,
+            })
+        ],
+    )
+
+    result = volumes_service.attach(VOLUME_ID, INSTANCE_ID)
+    assert result is None
+    assert responses.assert_call_count(endpoint, 1) is True
+```
+
+Key conventions:
+- **Every test method** in the test file must be decorated with `@responses.activate`.
+- Use `responses.add(METHOD, url, json=..., status=...)` for JSON responses.
+- Use `responses.add(METHOD, url, body=..., status=...)` for plain text responses (e.g. POST returning ID).
+- Use `responses.assert_call_count(url, N)` to verify the correct number of API calls.
+- Use `pytest.raises(APIException)` for error scenarios, checking both `.code` and `.message`.
+- Use `matchers.json_params_matcher(expected_dict)` in the `match=` parameter to assert request body contents.
+- Test classes follow `Test<ServiceName>Service` naming.
+- Module-level constants define fixture data (IDs, payloads).
+- Each test class has its own `service` and `endpoint` fixtures.
+- Tests follow arrange/act/assert pattern with comments.
+
+---
+
+## 11. Module `__init__.py` Pattern
+
+Each service package exports its service class and model classes:
+
+```python
+# verda/instances/__init__.py
+from ._instances import (
+    Contract,
+    Instance,
+    InstancesService,
+    OnSpotDiscontinue,
+    OSVolume,
+    Pricing,
+)
+```
+
+```python
+# verda/volumes/__init__.py
+from ._volumes import Volume, VolumesService
+```
+
+```python
+# verda/containers/__init__.py
+from ._containers import (
+    AWSECRCredentials,
+    BaseRegistryCredentials,
+    ComputeResource,
+    Container,
+    ContainerDeploymentStatus,
+    ContainerRegistryCredentials,
+    ContainerRegistrySettings,
+    ContainerRegistryType,
+    ContainersService,
+    CustomRegistryCredentials,
+    Deployment,
+    DockerHubCredentials,
+    # ... all public model classes
+)
+```
+
+The top-level `verda/__init__.py` only re-exports the client:
+```python
+from verda._verda import VerdaClient
+from verda._version import __version__
+
+__all__ = ['VerdaClient']
+```
+
+Convention: imports use the private module name (`._instances`), and every public class in the module must be listed in the `__init__.py` import.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `VolumesService.delete_by_id()` method using `DELETE /v1/volumes/{volume_id}` endpoint
 - Support for querying OS images by instance type via `verda.images.get(instance_type=...)`
 - Apache 2.0 license headers to all source files
+- `Container.should_use_cached_image` field for faster container startup via cached images
+- `ReplicaInfo.image`, `ReplicaInfo.image_name`, `ReplicaInfo.image_tag` fields for per-replica image details
+- `JobDeployment.created_by_user_id` and `JobDeploymentSummary.created_by_user_id` fields
 
 ### Changed
 

--- a/verda/containers/_containers.py
+++ b/verda/containers/_containers.py
@@ -253,6 +253,7 @@ class Container:
         entrypoint_overrides: Optional entrypoint override settings.
         env: Optional list of environment variables.
         volume_mounts: Optional list of volume mounts.
+        should_use_cached_image: Whether to use a cached image for faster startup.
     """
 
     image: str | dict
@@ -264,6 +265,7 @@ class Container:
     volume_mounts: list[VolumeMount] | None = field(
         default=None, metadata=config(decoder=_decode_volume_mounts)
     )
+    should_use_cached_image: bool | None = None
 
 
 @dataclass_json
@@ -575,11 +577,17 @@ class ReplicaInfo:
         id: Unique identifier of the replica.
         status: Current status of the replica.
         started_at: Timestamp when the replica was started.
+        image: Full image reference used by the replica.
+        image_name: Image name without tag.
+        image_tag: Image tag.
     """
 
     id: str
     status: str
     started_at: str
+    image: str | None = None
+    image_name: str | None = None
+    image_tag: str | None = None
 
 
 @dataclass_json

--- a/verda/job_deployments/_job_deployments.py
+++ b/verda/job_deployments/_job_deployments.py
@@ -52,6 +52,7 @@ class JobDeploymentSummary:
     name: str
     created_at: str
     compute: ComputeResource
+    created_by_user_id: str | None = None
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)
@@ -68,6 +69,7 @@ class JobDeployment:
     )
     endpoint_base_url: str | None = None
     created_at: str | None = None
+    created_by_user_id: str | None = None
 
 
 class JobDeploymentsService:


### PR DESCRIPTION
## Summary

Automated sync with verda-cloud/public-api@abc1234.

## Changes

### verda/containers/_containers.py
- `Container`: added `should_use_cached_image: bool | None = None` (corresponds to `ContainerPublicApiDto`, `PatchContainerPublicApiDto`, `CreateScaledJobContainerDto`, `PatchScaledJobContainerDto`)
- `ReplicaInfo`: added `image`, `image_name`, `image_tag` (all `str | None`, new in `ReplicaInfo` schema)

### verda/job_deployments/_job_deployments.py
- `JobDeploymentSummary`: added `created_by_user_id: str | None = None` (corresponds to `ScaledJobShortInfoResponseDto`)
- `JobDeployment`: added `created_by_user_id: str | None = None` (corresponds to `ScaledJobResponseDto`)

## Tests
149 unit tests pass (`uv run pytest tests/unit_tests -v`). `ruff check` and `ruff format --check` clean.

## Notes
All other spec differences were example UUID rotations only (no structural changes).